### PR TITLE
fix AP load tss error upon AP receiving second IPI&SIPI message 

### DIFF
--- a/guest/x86/cstart.S
+++ b/guest/x86/cstart.S
@@ -172,6 +172,10 @@ load_tss:
 	shr $24, %eax
 	mov %eax, %ebx
 	shl $3, %ebx
+	movl $0, tss_descr+8(%ebx)
+	movl $0, tss_descr+12(%ebx)
+	movl $0x00008900, tss_descr+4(%ebx)
+	movl $0x0000ffff, tss_descr(%ebx)
 	mov $((tss_end - tss) / max_cpus), %edx
 	imul %edx
 	add $tss, %eax

--- a/guest/x86/cstart64.S
+++ b/guest/x86/cstart64.S
@@ -263,6 +263,10 @@ load_tss:
 	shr $24, %eax
 	mov %eax, %ebx
 	shl $4, %ebx
+	movl $0, tss_descr+8(%rbx)
+	movl $0, tss_descr+12(%rbx)
+	movl $0x00008900, tss_descr+4(%rbx)
+	movl $0x0000ffff, tss_descr(%rbx)
 	mov $((tss_end - tss) / max_cpus), %edx
 	imul %edx
 	add $tss, %rax


### PR DESCRIPTION
clean tss_desc to default value