### PR TITLE
Enable 32-bit mode on unit test

### DIFF
--- a/guest/x86/Makefile.common
+++ b/guest/x86/Makefile.common
@@ -50,7 +50,7 @@ FLATLIBS = lib/libcflat.a $(libgcc)
 
 %.raw: %.elf
 	$(OBJCOPY) -O binary $^ $@.tmp
-	dd if=/dev/zero of=$@ bs=1 count=$(shell echo $$((0x`readelf -S $< | grep "\.text" | grep -E -o "[0-9a-f]{16}"` - 0x400000)))
+	dd if=/dev/zero of=$@ bs=1 count=$(shell echo $$((0x`readelf -S $< | grep "\.text" | grep -E -o "[0-9a-f]{$$(($(bits)/4))}"` - 0x400000)))
 	dd if=$@.tmp of=$@ conv=notrunc oflag=append
 	@rm $@.tmp
 	@chmod a-x $@
@@ -89,7 +89,7 @@ $(TEST_DIR)/stitched.elf: $(stitched-test-cases:.flat=_prelink.o) $(FLATLIBS) $(
 	@chmod a-x $@
 
 $(TEST_DIR)/%_prelink.o: $(TEST_DIR)/%.o
-	$(LD) -r -o $@ $^
+	$(LD) -m$(ldarch) -r -o $@ $^
 	@$(OBJCOPY) \
 		--keep-global-symbol=main \
 		--add-symbol main_$*=.text:0x`nm $@ | grep "T main" | egrep -o "[0-9a-f]{16}"`,function,global \

--- a/guest/x86/Makefile.i386
+++ b/guest/x86/Makefile.i386
@@ -1,6 +1,6 @@
 cstart.o = $(TEST_DIR)/cstart.o
 bits = 32
-ldarch = elf32-i386
+ldarch = elf_i386
 
 cflatobjs += lib/x86/setjmp32.o
 

--- a/guest/x86/Makefile.x86_64
+++ b/guest/x86/Makefile.x86_64
@@ -1,6 +1,6 @@
 cstart.o = $(TEST_DIR)/cstart64.o
 bits = 64
-ldarch = elf64-x86-64
+ldarch = elf_x86_64
 COMMON_CFLAGS += -mno-red-zone -mno-sse -mno-sse2
 
 cflatobjs += lib/x86/setjmp64.o

--- a/guest/x86/cstart.S
+++ b/guest/x86/cstart.S
@@ -8,7 +8,7 @@ ipi_vector = 0x20
 
 max_cpus = 64
 
-.bss
+.data
 
 	. = . + 4096 * max_cpus
 	.align 16
@@ -17,8 +17,6 @@ stacktop:
 	. = . + 4096
 	.align 16
 ring0stacktop:
-
-.data
 
 .align 4096
 pt:
@@ -96,6 +94,7 @@ MSR_GS_BASE = 0xc0000101
 start:
         mov $stacktop, %esp
         push %ebx
+        call bss_init
         call setup_multiboot
         call setup_libcflat
         mov mb_cmdline(%ebx), %eax


### PR DESCRIPTION
Update makefile to support 32-bit mode;
Fix a few bugs about bss initialization of 32-bit mode.

Signed-off-by: Xiangyang Wu <xiangyang.wu@linux.intel.com>