### PR TITLE
Build images in bzimage format for ACRN hypervisor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.flat
 *.elf
 *.raw
+*.bzimage
 .pc
 patches
 .stgit-*

--- a/guest/Makefile
+++ b/guest/Makefile
@@ -101,7 +101,7 @@ all: directories $(shell cd $(SRCDIR) && git rev-parse --verify --short=8 HEAD >
 standalone: all
 	@scripts/mkstandalone.sh
 
-stitched: $(TEST_DIR)/stitched.raw
+stitched: $(TEST_DIR)/stitched.bzimage
 
 install: standalone
 	mkdir -p $(DESTDIR)

--- a/guest/lib/x86/apic.c
+++ b/guest/lib/x86/apic.c
@@ -219,7 +219,12 @@ void set_irq_line(unsigned line, int val)
 void enable_apic(void)
 {
     printf("enabling apic\n");
-    xapic_write(0xf0, 0x1ff); /* spurious vector register */
+    if ((rdmsr(MSR_IA32_APICBASE) & (APIC_EN | APIC_EXTD)) != (APIC_EN | APIC_EXTD)) {
+        enable_x2apic();
+    } else {
+        apic_ops = &x2apic_ops;
+    }
+    apic_write(0xf0, 0x1ff); /* spurious vector register */
 }
 
 void mask_pic_interrupts(void)

--- a/guest/scripts/mk_bzimage.py
+++ b/guest/scripts/mk_bzimage.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python
+
+import sys, os
+import argparse
+
+version_string = "acrn-unit-test"
+
+def main(args):
+    out_f = open(args.out_file, "wb")
+    binary_f = open(args.raw_file, "rb")
+    binary_buf = binary_f.read()
+
+    # Sector #1
+
+    # # till 01F0: 0's
+    out_f.write("\x00" * 0x1f1)
+
+    # # 01F1/1: The size of the setup in sectors
+    out_f.write("\x02")
+
+    # # remaining till last 2 bytes of sector #1: 0's
+    out_f.write("\x00" * (0x200 - 2 - 0x1f2))
+    out_f.write("\x55\xAA")
+
+    # Sector #2: zero page header
+
+    # 0200/2: jump instruction
+    out_f.write("\xEB\x66")
+
+    # 0202/4: magic signature "HdrS"
+    out_f.write("HdrS")
+
+    # 0206/2: boot protocol version: 2.06
+    out_f.write("\x06\x02")
+
+    # 0208/4: realmode switch
+    out_f.write("\x00" * 4)
+
+    # 020C/2 (obsolete)
+    out_f.write("\x00" * 2)
+
+    # 020E/2: Pointer to kernel version string at the third sector
+    out_f.write("\x00\x02")
+
+    # 0210/1: Boot loader identifier (set by boot loader)
+    out_f.write("\x00")
+
+    # 0211/1: Boot protocol option flags: load at 1M
+    out_f.write("\x01")
+
+    # 0212/2: (for real-mode kernel)
+    out_f.write("\x00" * 2)
+
+    # 0214/4: code32_start: 1M
+    out_f.write("\x00\x00\x10\x00")
+
+    # 0218/4: ramdisk_image (set by boot loader)
+    out_f.write("\x00" * 4)
+
+    # 021C/4: initrd size (set by boot loader)
+    out_f.write("\x00" * 4)
+
+    # 0220/4: DO NOT USE
+    out_f.write("\x00" * 4)
+
+    # 0224/2: Free memory after setup end (write)
+    out_f.write("\x00" * 2)
+
+    # 0226/1: Extended boot loader version
+    out_f.write("\x00")
+
+    # 0227/1: Extended boot loader ID
+    out_f.write("\x00")
+
+    # 0228/4: 32-bit pointer to the kernel command line (write)
+    out_f.write("\x00" * 4)
+
+    # 022C/4: Highest legal initrd address (2G - 1)
+    out_f.write("\xFF\xFF\xFF\x7F")
+
+    # 0230/4: Physical addr alignment required for kernel (reloc)
+    out_f.write("\x00\x00\x00\x00")
+
+    # 0234/1: Whether kernel is relocatable or not (reloc)
+    out_f.write("\x01")
+
+    # 0235/1 (2.10+): Minimum alignment, as a power of two (reloc)
+    out_f.write("\x00")
+
+    # 0236/2 (2.12+): Boot protocol option flags
+    out_f.write("\x00" * 2)
+
+    # 0238/4: Maximum size of the kernel command line (0x07FF)
+    out_f.write("\xFF\x07\x00\x00")
+
+    # 023C/4 (2.07+): Hardware subarchitecture
+    # 0240/8 (2.07+): Subarchitecture-specific data
+    # Both defaults to 0
+    out_f.write("\x00" * (4 + 8))
+
+    # 0248/4 (2.08+): Offset of kernel payload
+    # 024C/4 (2.08+): Length of kernel payload
+    # Both 0
+    out_f.write("\x00" * (4 + 4))
+
+    # 0250/8 (2.09+): 64-bit physical pointer to linked list
+    out_f.write("\x00" * 8)
+
+    # 0258/8 (2.10+): Preferred loading address
+    #
+    # ACRN unit test images are statically linked at 4M and prepended by 4
+    # sectors (i.e. 2K). Tell a bootloader that the preferred load address is 4M - 2K.
+    pref_addr = 0x400000 - 512 * 4
+    for b in [((pref_addr >> i) & 0xff) for i in (0,8,16,24)]:
+        out_f.write(chr(b))
+    out_f.write("\x00" * 4)
+
+    # 0260/4 (2.10+): Linear memory required during initialization
+    out_f.write("\x00" * 4)
+
+    # 0264/4 (2.11+): Offset of handover entry point
+    out_f.write("\x00" * 4)
+
+    # remaining (except last 4 bytes): all 0
+    out_f.write("\x00" * (0x400 - 0x268 - 4))
+
+    # 03FC/4 (customized): size of the binary
+    binary_size = len(binary_buf)
+    for b in [((binary_size >> i) & 0xff) for i in (0,8,16,24)]:
+        out_f.write(chr(b))
+
+    # Sector #3: The version string at 0400, max 0200 bytes
+    out_f.write(version_string + "\x00" * (0x200 - len(version_string)))
+
+    # Sector $4: relocator code
+    with open(args.relocator, "rb") as in_f:
+        buf = in_f.read()
+        max_size = 0x200
+        if len(buf) > max_size:
+            print "Relocator too large: %d bytes (max %d bytes)" % (len(buf), max_size)
+            sys.exit(1)
+        out_f.write(buf)
+        out_f.write("\x00" * (max_size - len(buf)))
+
+    # Sector #5 and onwards: The binary
+    out_f.write(binary_buf)
+
+    out_f.close()
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Convert an test in raw to a bzImage")
+    parser.add_argument("raw_file")
+    parser.add_argument("relocator")
+    parser.add_argument("out_file")
+    args = parser.parse_args()
+
+    main(args)

--- a/guest/x86/Makefile.common
+++ b/guest/x86/Makefile.common
@@ -55,6 +55,12 @@ FLATLIBS = lib/libcflat.a $(libgcc)
 	@rm $@.tmp
 	@chmod a-x $@
 
+x86/bzimage_stub.raw: x86/bzimage_stub.o
+	@$(OBJCOPY) -O binary $^ $@
+
+%.bzimage: %.raw x86/bzimage_stub.raw
+	@scripts/mk_bzimage.py $+ $@
+
 tests-common = $(TEST_DIR)/vmexit.flat $(TEST_DIR)/tsc.flat \
                $(TEST_DIR)/smptest.flat  $(TEST_DIR)/port80.flat \
                $(TEST_DIR)/realmode.flat $(TEST_DIR)/msr.flat \

--- a/guest/x86/bzimage_stub.S
+++ b/guest/x86/bzimage_stub.S
@@ -1,0 +1,246 @@
+/*
+ * Stub code that serves as the entry of a bzimage to load a unit test image.
+ */
+
+#define MEM_1K             0x400
+#define MEM_2K             (2 * MEM_1K)
+#define MEM_4K             (4 * MEM_1K)
+#define MEM_1M             (1024 * MEM_1K)
+#define SECTOR_SIZE        (MEM_1K / 2)
+
+#define ZEROPAGE_MAGIC_SIG    0x53726448    /* "HdrS" in uint32_t */
+#define ZEROPAGE_SETUP_SECTS  0x1f1
+#define ZEROPAGE_HEADER       0x202
+#define ZEROPAGE_CMDLINE_PTR  0x228
+#define ZEROPAGE_IMAGE_SIZE   0x3fc
+#define ZEROPAGE_BINARY_BASE  (4 * SECTOR_SIZE)
+
+#define MBI_FLAGS             0x0
+#define MBI_MEM_LOWER         0x4
+#define MBI_MEM_UPPER         0x8
+#define MBI_CMDLINE           0x10
+#define MBI_MODS_COUNT        0x14
+
+#define MULTIBOOT_HEADER_MAGIC          0x1badb002
+#define MULTIBOOT_INFO_MAGIC		0x2badb002
+#define MULTIBOOT_INFO_HAS_MEMORY	0x00000001
+#define MULTIBOOT_INFO_HAS_BOOT_DEVICE	0x00000002
+#define MULTIBOOT_INFO_HAS_CMDLINE	0x00000004
+#define MULTIBOOT_INFO_HAS_MODS		0x00000008
+#define MULTIBOOT_INFO_HAS_AOUT_SYMS	0x00000010
+#define MULTIBOOT_INFO_HAS_ELF_SYMS	0x00000020
+#define MULTIBOOT_INFO_HAS_MMAP		0x00000040
+#define MULTIBOOT_INFO_HAS_DRIVES	0x00000080
+#define MULTIBOOT_INFO_HAS_CONFIG_TABLE	0x00000100
+#define MULTIBOOT_INFO_HAS_LOADER_NAME	0x00000200
+#define MULTIBOOT_INFO_HAS_APM_TABLE	0x00000400
+#define MULTIBOOT_INFO_HAS_VBE		0x00000800
+
+#define UNIT_TEST_LOAD_ADDRESS     (4 * MEM_1M)
+#define MBI_ADDRESS                (UNIT_TEST_LOAD_ADDRESS - MEM_4K)
+#define CMDLINE_ADDRESS            (UNIT_TEST_LOAD_ADDRESS - MEM_2K)
+
+#define UART_BASE          0x3f8
+#define UART_RBR           0x00
+#define UART_THR           0x00
+#define UART_DLL           0x00
+#define UART_IER           0x01
+#define UART_DLM           0x01
+#define UART_IIR           0x02
+#define UART_FCR           0x02
+#define UART_LCR           0x03
+#define UART_MCR           0x04
+#define UART_LSR           0x05
+#define UART_MSR           0x06
+#define UART_SCR           0x07
+
+	/* Register allocation
+	 *
+	 *     EAX: General, used for IN/OUT and as temporary variables
+	 *     EBX: General, used as a temporary variable
+	 *     ECX: General, used as iterators
+	 *     EDX: Used for IN/OUT when initializing UART and as the zero page pointer afterwards
+	 *     EBP: Used as the base of this stub before jumping to the trampoline, and bzimage pointer afterwards
+	 *     ESI: Used as the source iterator during copying
+	 *     EDI: Used as the destination iterator during copying
+	 */
+
+	.code32
+
+	/* Entry of the stub. Shall be the third sector in the bzimage. */
+start:
+	mov	$0xa0000, %esp
+
+	/* Init UART FIFOs */
+	mov	$(UART_BASE + UART_FCR), %dx
+	mov	$0x7, %al
+	outb	%al, %dx
+
+	/* Init UART data bits / parity bits / stop bits */
+	mov	$(UART_BASE + UART_LCR), %dx
+	mov	$0x3, %al
+	outb	%al, %dx
+
+	/* Disable UART interrupts */
+	mov	$(UART_BASE + UART_IER), %dx
+	mov	$0, %al
+	outb	%al, %dx
+
+	/* Set UART terminal ready and request to send */
+	mov	$(UART_BASE + UART_MCR), %dx
+	mov	$3, %al
+	outb	%al, %dx
+
+	mov	%esi, %edx
+
+	/* Copy trampoline code to the physical address 0. This is the place
+	 * where acrn-unit-test uses as the trampoline for starting APs as well. So
+	 * RAM at this address shall exists nonetheless.
+	 */
+
+	/* Identify base of the stub */
+	call	1f
+1:
+	pop	%ebp
+	and	$(~(SECTOR_SIZE-1)), %ebp
+
+	mov	%ebp, %esi
+	add	$(trampoline_start - start), %esi
+	xor	%edi, %edi
+	mov	$(trampoline_end - trampoline_start), %ecx
+	rep/movsb
+
+	xor	%eax, %eax
+	jmp	*%eax
+
+trampoline_start:
+
+	/* Convert the base of this stub to the base of the bzimage. */
+
+	mov	ZEROPAGE_SETUP_SECTS(%edx), %eax
+	add	$1, %eax
+	shl	$9, %eax       /* (x << 9) == (x * SECTOR_SIZE) */
+	sub	%eax, %ebp
+
+	/* Copy the unit test image to 4M. */
+
+	lea	ZEROPAGE_BINARY_BASE(%ebp), %esi
+	mov	$(UNIT_TEST_LOAD_ADDRESS), %edi
+	mov	ZEROPAGE_IMAGE_SIZE(%ebp), %ecx
+
+	/* If the address 4M locates in the range of the unit test image, copy
+	 * in the reversed order by setting EFLAGS.DF. */
+
+	cld
+	cmp	$(UNIT_TEST_LOAD_ADDRESS), %esi
+	jge	1f
+	mov	%esi, %eax
+	add	%ecx, %eax
+	cmp	$(UNIT_TEST_LOAD_ADDRESS), %eax
+	jl	1f
+
+	add	%ecx, %esi
+	sub	$1, %esi
+	add	%ecx, %edi
+	sub	$1, %edi
+	std
+
+1:
+	rep/movsb
+	cld
+
+	/* Construct a simple multiboot header for the unit test. */
+
+	mov	$MBI_ADDRESS, %esi
+
+	mov	$(MULTIBOOT_INFO_HAS_MEMORY | MULTIBOOT_INFO_HAS_CMDLINE | MULTIBOOT_INFO_HAS_MODS), %eax
+	mov	%eax, MBI_FLAGS(%esi)
+
+	mov	$0, %eax
+	mov	%eax, MBI_MEM_LOWER(%esi)
+	mov	%eax, MBI_MODS_COUNT(%esi)
+
+	/* TODO: parse the end of memory from e820 */
+	mov	$(MEM_1M / MEM_1K * 512), %eax
+	mov	%eax, MBI_MEM_UPPER(%esi)
+
+	mov	$(CMDLINE_ADDRESS), %eax
+	mov	%eax, MBI_CMDLINE(%esi)
+
+	mov	ZEROPAGE_CMDLINE_PTR(%edx), %esi
+	mov	$(CMDLINE_ADDRESS), %edi
+	mov	$(MEM_2K), %ecx
+	repnz/movsb
+
+	/* Identify the entry which is right after the multiboot header. */
+
+	mov	0, %ecx
+	mov	$(UNIT_TEST_LOAD_ADDRESS), %esi
+1:
+	mov	0(%esi), %eax
+	cmp	$(MULTIBOOT_HEADER_MAGIC), %eax
+	jz	_call_entry
+	add	$4, %ecx
+	add	$4, %esi
+	cmp	$(8 * MEM_1K), %ecx
+	jnz	1b
+
+	/* Prepare for the defined register states and Jump to the entry. */
+_call_entry:
+
+	/* The multiboot header is 12 bytes, followed by the entry point. */
+
+	add	$12, %esi
+	mov	$MULTIBOOT_INFO_MAGIC, %eax
+	mov	$MBI_ADDRESS, %ebx
+	jmp	*%esi
+
+print_edi:
+	push	%eax
+	push	%ebx
+	push	%ecx
+	push	%edx
+
+	mov	$32, %cl
+
+1:
+	cmp	$0, %cl
+	jz	_print_edi_end
+
+	sub	$4, %cl
+	mov	%edi, %ebx
+	shr	%cl, %ebx
+	andb	$0xf, %bl
+	addb	$0x30, %bl
+	cmp	$0x39, %bl
+	jle	2f
+	addb	$(0x61-0x3a), %bl
+2:
+
+	mov	$(UART_BASE + UART_LSR), %dx
+3:
+	inb	%dx, %al
+	andb	$0x60, %al
+	cmp	$0x60, %al
+	jnz	3b
+
+	mov	%bl, %al
+	mov	$(UART_BASE + UART_THR), %dx
+	outb	%al, %dx
+	jmp	1b
+
+_print_edi_end:
+	/* Print a newline at the end */
+	mov	$0x0d, %al
+	outb	%al, %dx
+	mov	$0x0a, %al
+	outb	%al, %dx
+
+	pop	%edx
+	pop	%ecx
+	pop	%ebx
+	pop	%eax
+
+	ret
+
+trampoline_end:

--- a/guest/x86/cstart64.S
+++ b/guest/x86/cstart64.S
@@ -215,9 +215,8 @@ ap_start32:
 
 .code64
 ap_start64:
-	call load_tss
 	call enable_apic
-	call enable_x2apic
+	call load_tss
 	sti
 	nop
 	lock incw cpu_online_count
@@ -227,11 +226,10 @@ ap_start64:
 
 start64:
 	call bss_init
+	call enable_apic
 	call load_tss
 	call mask_pic_interrupts
-	call enable_apic
 	call smp_init
-	call enable_x2apic
 	mov mb_boot_info(%rip), %rbx
 	mov %rbx, %rdi
 	call setup_multiboot
@@ -265,9 +263,11 @@ idt_descr:
 
 load_tss:
 	lidtq idt_descr
-	mov $(APIC_DEFAULT_PHYS_BASE + APIC_ID), %eax
-	mov (%rax), %eax
-	shr $24, %eax
+
+	movl $APIC_ID, %ecx
+	shrl $4, %ecx
+	addl $APIC_BASE_MSR, %ecx
+	rdmsr
 	mov %eax, %ebx
 	shl $4, %ebx
 	movl $0, tss_descr+8(%rbx)
@@ -294,10 +294,25 @@ smp_init:
 	xor %rdi, %rdi
 	mov $(sipi_end - sipi_entry), %rcx
 	rep/movsb
-	mov $APIC_DEFAULT_PHYS_BASE, %eax
-	movl $(APIC_DEST_ALLBUT | APIC_DEST_PHYSICAL | APIC_DM_INIT | APIC_INT_ASSERT), APIC_ICR(%rax)
-	movl $(APIC_DEST_ALLBUT | APIC_DEST_PHYSICAL | APIC_DM_INIT), APIC_ICR(%rax)
-	movl $(APIC_DEST_ALLBUT | APIC_DEST_PHYSICAL | APIC_DM_STARTUP), APIC_ICR(%rax)
+
+	movl $APIC_ICR, %ecx
+	shrl $4, %ecx
+	addl $APIC_BASE_MSR, %ecx
+
+	call fwcfg_get_nb_cpus
+	movl %eax, %edx
+	subl $1, %edx
+1:
+	movl $(APIC_DEST_PHYSICAL | APIC_DM_INIT | APIC_INT_ASSERT), %eax
+	wrmsr
+	movl $(APIC_DEST_PHYSICAL | APIC_DM_INIT), %eax
+	wrmsr
+	movl $(APIC_DEST_PHYSICAL | APIC_DM_STARTUP), %eax
+	wrmsr
+	subl $1, %edx
+	cmp $0, %edx
+	jnz 1b
+
 	call fwcfg_get_nb_cpus
 1:	pause
 	cmpw %ax, cpu_online_count


### PR DESCRIPTION
For now ACRN hypervisor supports loading bzimage or raw Zephyr image as the guest kernel for pre-launched VMs. But acrn-unit-test binaries are in multiboot format and rely on the multiboot information structures for memory layout and command line. An additional multiboot loader is added to the hypervisor previously to enable running acrn-unit-test in the logical partition scenario, but maintaining the loader outside the mainline is a pain considering the rapid evolution of internal structures and APIs of the hypervisor.

This PR takes another way to enable acrn-unit-test in such cases, i.e. convert the acrn-unit-test images to the bzimage format. To minimize the impact to the existing code, a stub is prepended to the original raw image to move the test image to the right place (currently the physical address at 4M), construct a multiboot information structure based on the given zero page and jump to the real entry of the test.