### PR TITLE
x86: lib: spin upon power off failure

### DIFF
--- a/guest/lib/x86/io.c
+++ b/guest/lib/x86/io.c
@@ -99,6 +99,7 @@ void exit(int code)
 #else
         asm volatile("out %0, %1" : : "a"(code), "d"((short)0xf4));
 #endif
+        while (1);
 }
 
 void __iomem *ioremap(phys_addr_t phys_addr, size_t size)


### PR DESCRIPTION
The function exit() is not expected to return and can cause unpredictable
behavior if it does instead. The current implementation attempts to power off
the platform using multiple ways but assumes at least one of it succeeds, which
is not the case atop ACRN hypervisor in partition mode.

This patch adds a dead loop at the end of exit() to make sure that a unit-test
spins when the platform cannot be powered off and causes no unwanted misbehavior.

Signed-off-by: Junjie Mao <junjie.mao@intel.com>